### PR TITLE
respect XDG_CONFIG_HOME on Linux, use as default

### DIFF
--- a/cmd/beatportdl/interactions.go
+++ b/cmd/beatportdl/interactions.go
@@ -13,13 +13,13 @@ import (
 )
 
 func Setup() (cfg *config.AppConfig, cachePath string, err error) {
-	configFilePath, err := FindFile(configFilename)
+	configFilePath, exists, err := FindFile(configFilename)
 	if err != nil {
-		fmt.Println("Config file not found, creating a new one")
-		configFilePath, err = ExecutableDirFilePath(configFilename)
-		if err != nil {
-			return nil, configFilePath, fmt.Errorf("get executable path: %w", err)
-		}
+		return nil, "", err
+	}
+
+	if !exists {
+		fmt.Println("Config file not found, creating a new one:", configFilePath)
 
 		fmt.Print("Username: ")
 		username := GetLine()

--- a/cmd/beatportdl/main.go
+++ b/cmd/beatportdl/main.go
@@ -19,6 +19,7 @@ import (
 const (
 	configFilename = "beatportdl-config.yml"
 	cacheFilename  = "beatportdl-credentials.json"
+	errorFilename  = "beatportdl-err.log"
 )
 
 type application struct {
@@ -69,7 +70,7 @@ func main() {
 	}()
 
 	if cfg.WriteErrorLog {
-		logFilePath, err := ExecutableDirFilePath("error.log")
+		logFilePath, _, err := FindFile(errorFilename)
 		if err != nil {
 			fmt.Println(err.Error())
 			Pause()

--- a/cmd/beatportdl/utils.go
+++ b/cmd/beatportdl/utils.go
@@ -4,16 +4,19 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/vbauerster/mpb/v8"
-	"github.com/vbauerster/mpb/v8/decor"
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/fatih/color"
+	"github.com/vbauerster/mpb/v8"
+	"github.com/vbauerster/mpb/v8/decor"
 )
 
 func (app *application) globalWorker(fn func()) {
@@ -197,28 +200,40 @@ func WorkingDirFilePath(fileName string) (string, error) {
 	return filePathCurrent, nil
 }
 
-func FindFile(fileName string) (string, error) {
-	filePathExec, err := ExecutableDirFilePath(fileName)
-	if err != nil {
-		return "", fmt.Errorf("failed to get executable path: %v", err)
-	}
-
-	_, err = os.Stat(filePathExec)
-	if err == nil {
-		return filePathExec, nil
-	}
-
+func FindFile(fileName string) (string, bool, error) {
 	filePathCurrent, err := WorkingDirFilePath(fileName)
 	if err != nil {
-		return "", fmt.Errorf("failed to get working directory: %v", err)
+		return "", false, err
 	}
 
-	_, err = os.Stat(filePathCurrent)
-	if err == nil {
-		return filePathCurrent, nil
+	filePathExec, err := ExecutableDirFilePath(fileName)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to get executable path: %v", err)
 	}
 
-	return "", fmt.Errorf("%s not found", fileName)
+	configFilePaths := []string{
+		filePathCurrent,
+		filePathExec,
+	}
+
+	if runtime.GOOS == "linux" {
+		if xdgCfgHome, exists := os.LookupEnv("XDG_CONFIG_HOME"); exists {
+			configFilePaths = append(configFilePaths, path.Join(xdgCfgHome, "beatportdl", fileName))
+		} else {
+			configFilePaths = append(configFilePaths, path.Join(os.Getenv("HOME"), ".config", "beatportdl", fileName))
+		}
+	}
+
+	for _, configFilePath := range configFilePaths {
+		_, err = os.Stat(configFilePath)
+		if err == nil {
+			return configFilePath, true, nil
+		}
+	}
+
+	// last entry in list is default
+	defaultFilePath := configFilePaths[len(configFilePaths)-1]
+	return defaultFilePath, false, nil
 }
 
 func CreateDirectory(directory string) error {

--- a/config/config.go
+++ b/config/config.go
@@ -3,10 +3,12 @@ package config
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"os"
 	"os/exec"
+	"path"
 	"unspok3n/beatportdl/internal/validator"
+
+	"gopkg.in/yaml.v2"
 )
 
 type AppConfig struct {
@@ -144,11 +146,17 @@ func Parse(filePath string) (*AppConfig, error) {
 }
 
 func (c *AppConfig) Save(filePath string) error {
+	err := os.MkdirAll(path.Dir(filePath), 0700)
+	if err != nil {
+		return fmt.Errorf("could not create folder for configuration file: %w", err)
+	}
+
 	file, err := os.Create(filePath)
 	if err != nil {
 		return fmt.Errorf("create file: %w", err)
 	}
 	defer file.Close()
+
 	encoder := yaml.NewEncoder(file)
 	if err := encoder.Encode(&c); err != nil {
 		return fmt.Errorf("encode config: %w", err)


### PR DESCRIPTION
On Linux you usually don't use the folder of the binary to store config- or cache-files. I therefor implemented the use of the XDG_CONFIG_HOME env variable as a last but default option.

More info about this here: https://specifications.freedesktop.org/basedir-spec/latest/