### PR TITLE
respect XDG_CONFIG_HOME on Linux, use as default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ error.log
 beatportdl-credentials.json
 beatportdl-config.yml
 downloads/
-beatportdl
+./beatportdl

--- a/cmd/beatportdl/interactions.go
+++ b/cmd/beatportdl/interactions.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Setup() (cfg *config.AppConfig, cachePath string, err error) {
-	configFilePath, exists, err := FindFile(configFilename)
+	configFilePath, exists, err := FindConfigFile()
 	if err != nil {
 		return nil, "", err
 	}
@@ -64,7 +64,7 @@ func Setup() (cfg *config.AppConfig, cachePath string, err error) {
 		return nil, configFilePath, fmt.Errorf("load config: %w", err)
 	}
 
-	cacheFilePath, exists, err := FindFile(cacheFilename)
+	cacheFilePath, exists, err := FindCacheFile()
 	if err != nil {
 		return nil, configFilePath, fmt.Errorf("get executable path: %w", err)
 	}

--- a/cmd/beatportdl/interactions.go
+++ b/cmd/beatportdl/interactions.go
@@ -13,13 +13,13 @@ import (
 )
 
 func Setup() (cfg *config.AppConfig, cachePath string, err error) {
-	configFilePath, err := FindFile(configFilename)
+	configFilePath, exists, err := FindFile(configFilename)
 	if err != nil {
-		fmt.Println("Config file not found, creating a new one")
-		configFilePath, err = ExecutableDirFilePath(configFilename)
-		if err != nil {
-			return nil, configFilePath, fmt.Errorf("get executable path: %w", err)
-		}
+		return nil, "", err
+	}
+
+	if !exists {
+		fmt.Println("Config file not found, creating a new one:", configFilePath)
 
 		fmt.Print("Username: ")
 		username := GetLine()
@@ -64,22 +64,9 @@ func Setup() (cfg *config.AppConfig, cachePath string, err error) {
 		return nil, configFilePath, fmt.Errorf("load config: %w", err)
 	}
 
-	execCachePath, err := ExecutableDirFilePath(cacheFilename)
+	cacheFilePath, exists, err := FindFile(cacheFilename)
 	if err != nil {
 		return nil, configFilePath, fmt.Errorf("get executable path: %w", err)
-	}
-	cacheFilePath := execCachePath
-
-	_, err = os.Stat(cacheFilePath)
-	if err != nil {
-		workingCachePath, err := WorkingDirFilePath(cacheFilename)
-		if err != nil {
-			return nil, configFilePath, fmt.Errorf("get working dir path: %w", err)
-		}
-		_, err = os.Stat(workingCachePath)
-		if err == nil {
-			cacheFilePath = workingCachePath
-		}
 	}
 
 	return parsedConfig, cacheFilePath, nil

--- a/cmd/beatportdl/main.go
+++ b/cmd/beatportdl/main.go
@@ -19,6 +19,7 @@ import (
 const (
 	configFilename = "beatportdl-config.yml"
 	cacheFilename  = "beatportdl-credentials.json"
+	errorFilename  = "beatportdl-err.log"
 )
 
 type application struct {
@@ -73,7 +74,7 @@ func main() {
 	}()
 
 	if cfg.WriteErrorLog {
-		logFilePath, err := ExecutableDirFilePath("error.log")
+		logFilePath, _, err := FindFile(errorFilename)
 		if err != nil {
 			fmt.Println(err.Error())
 			Pause()

--- a/cmd/beatportdl/main.go
+++ b/cmd/beatportdl/main.go
@@ -74,7 +74,7 @@ func main() {
 	}()
 
 	if cfg.WriteErrorLog {
-		logFilePath, _, err := FindFile(errorFilename)
+		logFilePath, _, err := FindErrorLogFile()
 		if err != nil {
 			fmt.Println(err.Error())
 			Pause()

--- a/cmd/beatportdl/utils_test.go
+++ b/cmd/beatportdl/utils_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"os"
+	"path"
+	"testing"
+)
+
+func TestFindConfigFile(t *testing.T) {
+	xdgConfigHome := "/tmp/foo/bar"
+
+	t.Run("Use default XDG_CONFIG_HOME without env being set", func(t *testing.T) {
+		configFilePath, _, gotErr := FindConfigFile()
+		if gotErr != nil {
+			t.Errorf("FindConfigFile() failed: %v", gotErr)
+			return
+		}
+
+		expectedPath := path.Join(os.Getenv("HOME"), ".config", "beatportdl", configFilename)
+
+		if expectedPath != configFilePath {
+			t.Errorf("Paths do not match %s != %s", expectedPath, configFilePath)
+		}
+	})
+
+	t.Run("Use XDG_CONFIG_HOME with env being set", func(t *testing.T) {
+		os.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
+
+		configFilePath, _, gotErr := FindConfigFile()
+		if gotErr != nil {
+			t.Errorf("FindConfigFile() failed: %v", gotErr)
+			return
+		}
+
+		expectedPath := path.Join(xdgConfigHome, "beatportdl", configFilename)
+
+		if expectedPath != configFilePath {
+			t.Errorf("Paths do not match %s != %s", expectedPath, configFilePath)
+		}
+	})
+}
+
+func TestFindCacheFile(t *testing.T) {
+	xdgStateHome := "/tmp/foo/bar"
+
+	t.Run("Use default XDG_STATE_HOME without env being set", func(t *testing.T) {
+		cacheFilePath, _, gotErr := FindCacheFile()
+		if gotErr != nil {
+			t.Errorf("FindCacheFile() failed: %v", gotErr)
+			return
+		}
+
+		expectedPath := path.Join(os.Getenv("HOME"), ".local/state", "beatportdl", cacheFilename)
+
+		if expectedPath != cacheFilePath {
+			t.Errorf("Paths do not match %s != %s", expectedPath, cacheFilePath)
+		}
+	})
+
+	t.Run("Use XDG_STATE_HOME with env being set", func(t *testing.T) {
+		os.Setenv("XDG_STATE_HOME", xdgStateHome)
+
+		cacheFilePath, _, gotErr := FindCacheFile()
+		if gotErr != nil {
+			t.Errorf("FindCacheFile() failed: %v", gotErr)
+			return
+		}
+
+		expectedPath := path.Join(xdgStateHome, "beatportdl", cacheFilename)
+
+		if expectedPath != cacheFilePath {
+			t.Errorf("Paths do not match, %s != %s", expectedPath, cacheFilePath)
+		}
+	})
+}

--- a/config/config.go
+++ b/config/config.go
@@ -3,10 +3,12 @@ package config
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"os"
 	"os/exec"
+	"path"
 	"unspok3n/beatportdl/internal/validator"
+
+	"gopkg.in/yaml.v2"
 )
 
 type AppConfig struct {
@@ -144,11 +146,17 @@ func Parse(filePath string) (*AppConfig, error) {
 }
 
 func (c *AppConfig) Save(filePath string) error {
+	err := os.MkdirAll(path.Dir(filePath), 0700)
+	if err != nil {
+		return fmt.Errorf("could not create folder for configuration file: %w", err)
+	}
+
 	file, err := os.Create(filePath)
 	if err != nil {
 		return fmt.Errorf("create file: %w", err)
 	}
 	defer file.Close()
+
 	encoder := yaml.NewEncoder(file)
 	if err := encoder.Encode(&c); err != nil {
 		return fmt.Errorf("encode config: %w", err)

--- a/internal/beatport/auth.go
+++ b/internal/beatport/auth.go
@@ -8,6 +8,7 @@ import (
 	"hash/fnv"
 	"net/url"
 	"os"
+	"path"
 	"sync"
 	"time"
 )
@@ -75,6 +76,11 @@ func (a *Auth) WriteCache() error {
 	data, err := json.MarshalIndent(a.tokenPair, "", " ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal tokenPair: %w", err)
+	}
+
+	err = os.MkdirAll(path.Dir(a.cacheFile), 0700)
+	if err != nil {
+		return fmt.Errorf("could not create folder for cache file: %w", err)
 	}
 
 	if err := os.WriteFile(a.cacheFile, data, 0600); err != nil {


### PR DESCRIPTION
This commit sets the default for a Linux environment to use `~/.config/beatportdl` for the configuration and cache files.