### PR TITLE
fix: first_genre to use genre of the first track in the playlist or c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,35 +2,39 @@
 
 Beatport & Beatsource downloader (FLAC, AAC)
 
-*Requires an active [Beatport](https://stream.beatport.com/) or [Beatsource](https://stream.beatsource.com/) streaming plan.*
+_Requires an active [Beatport](https://stream.beatport.com/) or [Beatsource](https://stream.beatsource.com/) streaming plan._
 
 ![Screenshot](/screenshots/main.png?raw=true "Screenshot")
 
-Setup
----
+## Setup
+
 1. [Download](https://github.com/unspok3n/beatportdl/releases/) or [build](#building) BeatportDL.
 
-     *Compiled binaries for Windows, macOS (amd64, arm64) and Linux (amd64, arm64) are available on the [Releases](https://github.com/unspok3n/beatportdl/releases) page.* \
-     *Don't forget to set the execute permission on unix systems, e.g., chmod +x beatportdl-darwin-arm64*
+   _Compiled binaries for Windows, macOS (amd64, arm64) and Linux (amd64, arm64) are available on the [Releases](https://github.com/unspok3n/beatportdl/releases) page._ \
+    _Don't forget to set the execute permission on unix systems, e.g., chmod +x beatportdl-darwin-arm64_
 
 2. Run beatportdl (e.g. `./beatportdl-darwin-arm64`), then specify the:
+
    - Beatport username
    - Beatport password
    - Downloads directory
    - Audio quality
 
 3. OPTIONAL: Customize a config file. Create a new config file by running:
+
 ```shell
 ./beatportdl
 ```
+
 This will create a new `beatportdl-config.yml` file. You can put the following options and values into the config file:
 
 ---
+
 | Option                        | Default Value                             | Type       | Description                                                                                                                                                                               |
-|-------------------------------|-------------------------------------------|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ----------------------------- | ----------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `username`                    |                                           | String     | Beatport username                                                                                                                                                                         |
 | `password`                    |                                           | String     | Beatport password                                                                                                                                                                         |
-| `quality`                     | lossless                                  | String     | Download quality *(medium-hls, medium, high, lossless)*                                                                                                                                   |
+| `quality`                     | lossless                                  | String     | Download quality _(medium-hls, medium, high, lossless)_                                                                                                                                   |
 | `show_progress`               | true                                      | Boolean    | Enable progress bars                                                                                                                                                                      |
 | `write_error_log`             | false                                     | Boolean    | Write errors to `error.log`                                                                                                                                                               |
 | `max_download_workers`        | 15                                        | Integer    | Concurrent download jobs limit                                                                                                                                                            |
@@ -41,10 +45,10 @@ This will create a new `beatportdl-config.yml` file. You can put the following o
 | `force_release_directories`   | false                                     | Boolean    | Create release directories inside chart and playlist folders (requires `sort_by_context`)                                                                                                 |
 | `track_exists`                | update                                    | String     | Behavior when track file already exists                                                                                                                                                   |
 | `track_number_padding`        | 2                                         | Integer    | Track number padding for filenames and tag mappings (when using `track_number_with_padding` or `release_track_count_with_padding`)<br/> Set to 0 for dynamic padding based on track count |
-| `cover_size`                  | 1400x1400                                 | String     | Cover art size for `keep_cover` and track metadata (if `fix_tags` is enabled)  *[max: 1400x1400]*                                                                                         |
+| `cover_size`                  | 1400x1400                                 | String     | Cover art size for `keep_cover` and track metadata (if `fix_tags` is enabled) _[max: 1400x1400]_                                                                                          |
 | `keep_cover`                  | false                                     | Boolean    | Download cover art file (cover.jpg) to the context directory (requires `sort_by_context`)                                                                                                 |
 | `fix_tags`                    | true                                      | Boolean    | Enable tag writing capabilities                                                                                                                                                           |
-| `tag_mappings`                | *Listed below*                            | String Map | Custom tag mappings                                                                                                                                                                       |
+| `tag_mappings`                | _Listed below_                            | String Map | Custom tag mappings                                                                                                                                                                       |
 | `track_file_template`         | {number}. {artists} - {name} ({mix_name}) | String     | Track filename template                                                                                                                                                                   |
 | `release_directory_template`  | [{catalog_number}] {artists} - {name}     | String     | Release directory template                                                                                                                                                                |
 | `playlist_directory_template` | {name} [{created_date}]                   | String     | Playlist directory template                                                                                                                                                               |
@@ -58,75 +62,82 @@ This will create a new `beatportdl-config.yml` file. You can put the following o
 | `proxy`                       |                                           | String     | Proxy URL                                                                                                                                                                                 |
 
 If the Beatport credentials are correct, you should also see the file `beatportdl-credentials.json` appear in the BeatportDL directory.
-*If you accidentally entered an incorrect password and got an error, you can always manually edit the config file*
+_If you accidentally entered an incorrect password and got an error, you can always manually edit the config file_
 
 Download quality options, per Beatport/Beatsource subscription type:
 
 | Option       | Description                                                                                                  | Requires at least              | Notes                                                                   |
-|--------------|--------------------------------------------------------------------------------------------------------------|--------------------------------|-------------------------------------------------------------------------|
+| ------------ | ------------------------------------------------------------------------------------------------------------ | ------------------------------ | ----------------------------------------------------------------------- |
 | `medium-hls` | 128 kbps AAC through `/stream` endpoint (IMPORTANT: requires [ffmpeg](https://www.ffmpeg.org/download.html)) | Essential / Beatsource         | Same as `medium` on Advanced but uses a slightly slower download method |
 | `medium`     | 128 kbps AAC                                                                                                 | Advanced / Beatsource Pro+     |                                                                         |
 | `high`       | 256 kbps AAC                                                                                                 | Professional / Beatsource Pro+ |                                                                         |
 | `lossless`   | 44.1 kHz FLAC                                                                                                | Professional / Beatsource Pro+ |                                                                         |
 
 Available `track_exists` options:
-* `error` Log error and skip
-* `skip` Skip silently
-* `overwrite` Re-download
-* `update` Update tags
+
+- `error` Log error and skip
+- `skip` Skip silently
+- `overwrite` Re-download
+- `update` Update tags
 
 Available template keywords for filenames and directories (`*_template`):
-* Track: `id`,`name`,`mix_name`,`slug`,`artists`,`remixers`,`number`,`length`,`key`,`bpm`,`genre`,`subgenre`,`genre_with_subgenre`,`subgenre_or_genre`,`isrc`,`label`
-* Release: `id`,`name`,`slug`,`artists`,`remixers`,`date`,`year`,`track_count`,`bpm_range`,`catalog_number`,`upc`,`label`
-* Playlist: `id`,`name`,`first_genre`,`track_count`,`bpm_range`,`length`,`created_date`,`updated_date`
-* Chart: `id`,`name`,`slug`,`first_genre`,`track_count`,`creator`,`created_date`,`published_date`,`updated_date`
-* Artist: `id`, `name`, `slug`
-* Label: `id`, `name`, `slug`, `created_date`, `updated_date`
+
+- Track: `id`,`name`,`mix_name`,`slug`,`artists`,`remixers`,`number`,`length`,`key`,`bpm`,`genre`,`subgenre`,`genre_with_subgenre`,`subgenre_or_genre`,`isrc`,`label`
+- Release: `id`,`name`,`slug`,`artists`,`remixers`,`date`,`year`,`track_count`,`bpm_range`,`catalog_number`,`upc`,`label`
+- Playlist: `id`,`name`,`first_genre`,`track_count`,`bpm_range`,`length`,`created_date`,`updated_date`
+- Chart: `id`,`name`,`slug`,`first_genre`,`track_count`,`creator`,`created_date`,`published_date`,`updated_date`
+
+**Note:** The `first_genre` parameter for playlists and charts now uses the genre of the first track in the playlist/chart, rather than relying on metadata. This ensures more accurate genre-based folder organization.
+
+- Artist: `id`, `name`, `slug`
+- Label: `id`, `name`, `slug`, `created_date`, `updated_date`
 
 Default `tag_mappings` config:
+
 ```yaml
 tag_mappings:
-   flac:
-      track_name: "TITLE"
-      track_artists: "ARTIST"
-      track_number: "TRACKNUMBER"
-      track_subgenre_or_genre: "GENRE"
-      track_key: "KEY"
-      track_bpm: "BPM"
-      track_isrc: "ISRC"
-   
-      release_name: "ALBUM"
-      release_artists: "ALBUMARTIST"
-      release_date: "DATE"
-      release_track_count: "TOTALTRACKS"
-      release_catalog_number: "CATALOGNUMBER"
-      release_label: "LABEL"
-   m4a:
-      track_name: "TITLE"
-      track_artists: "ARTIST"
-      track_number: "TRACKNUMBER"
-      track_genre: "GENRE"
-      track_key: "KEY"
-      track_bpm: "BPM"
-      track_isrc: "ISRC"
-   
-      release_name: "ALBUM"
-      release_artists: "ALBUMARTIST"
-      release_date: "DATE"
-      release_track_count: "TOTALTRACKS"
-      release_catalog_number: "CATALOGNUMBER"
-      release_label: "LABEL"
+  flac:
+    track_name: "TITLE"
+    track_artists: "ARTIST"
+    track_number: "TRACKNUMBER"
+    track_subgenre_or_genre: "GENRE"
+    track_key: "KEY"
+    track_bpm: "BPM"
+    track_isrc: "ISRC"
+
+    release_name: "ALBUM"
+    release_artists: "ALBUMARTIST"
+    release_date: "DATE"
+    release_track_count: "TOTALTRACKS"
+    release_catalog_number: "CATALOGNUMBER"
+    release_label: "LABEL"
+  m4a:
+    track_name: "TITLE"
+    track_artists: "ARTIST"
+    track_number: "TRACKNUMBER"
+    track_genre: "GENRE"
+    track_key: "KEY"
+    track_bpm: "BPM"
+    track_isrc: "ISRC"
+
+    release_name: "ALBUM"
+    release_artists: "ALBUMARTIST"
+    release_date: "DATE"
+    release_track_count: "TOTALTRACKS"
+    release_catalog_number: "CATALOGNUMBER"
+    release_label: "LABEL"
 ```
 
 As you can see, each key here represents a predefined value from either a release or a track that you can use to customize what is written to which tags. When you add an entry in the mappings for any format (for e.g., `flac`), only the tags that you specify will be written.
 
-All tags by default are converted to uppercase, but since some M4A players might not recognize it, you can write the tag in lowercase and add the `_raw` suffix to bypass the conversion. *(This applies to M4A tags only)*
+All tags by default are converted to uppercase, but since some M4A players might not recognize it, you can write the tag in lowercase and add the `_raw` suffix to bypass the conversion. _(This applies to M4A tags only)_
 
 For e.g., Traktor doesn't recognize the track key tag in uppercase, so you have to add:
+
 ```yaml
 tag_mappings:
-   m4a:
-      track_key: "initialkey_raw"
+  m4a:
+    track_key: "initialkey_raw"
 ```
 
 Available `tag_mappings` keys: `track_id`,`track_url`,`track_name`,`track_artists`,`track_artists_limited`,`track_remixers`,`track_remixers_limited`,`track_number`,`track_number_with_padding`,`track_number_with_total`,`track_genre`,`track_subgenre`,`track_genre_with_subgenre`,`track_subgenre_or_genre`,`track_key`,`track_bpm`,`track_isrc`,`release_id`,`release_url`,`release_name`,`release_artists`,`release_artists_limited`,`release_remixers`,`release_remixers_limited`,`release_date`,`release_year`,`release_track_count`,`release_track_count_with_padding`,`release_catalog_number`,`release_upc`,`release_label`,`release_label_url`
@@ -134,7 +145,7 @@ Available `tag_mappings` keys: `track_id`,`track_url`,`track_name`,`track_artist
 Available `key_system` options:
 
 | System           | Example           |
-|------------------|-------------------|
+| ---------------- | ----------------- |
 | `standard`       | Eb Minor, F Major |
 | `standard-short` | Ebm, F            |
 | `openkey`        | 7m, 12d           |
@@ -142,33 +153,38 @@ Available `key_system` options:
 
 Proxy URL format example: `http://username:password@127.0.0.1:8080`
 
-Usage
----
+## Usage
 
 Run BeatportDL and enter Beatport or Beatsource URL or search query:
+
 ```shell
 ./beatportdl
 Enter url or search query:
 ```
+
 By default, search returns the results from beatport, if you want to search on beatsource instead, include `@beatsource` tag in the query
 
 ...or specify the URL using positional arguments:
+
 ```shell
 ./beatportdl https://www.beatport.com/track/strobe/1696999 https://www.beatport.com/track/move-for-me/591753
 ```
+
 ...or provide a text file with urls (separated by a newline)
+
 ```shell
 ./beatportdl file.txt file2.txt
 ```
 
 URL types that are currently supported: **Tracks, Releases, Playlists, Charts, Labels, Artists**
 
-Building
----
+## Building
+
 Required dependencies:
-* [TagLib](https://github.com/taglib/taglib) >= 2.0
-* [zlib](https://github.com/madler/zlib) >= 1.2.3
-* [Zig C/C++ Toolchain](https://github.com/ziglang/zig) >= 0.14.0
+
+- [TagLib](https://github.com/taglib/taglib) >= 2.0
+- [zlib](https://github.com/madler/zlib) >= 1.2.3
+- [Zig C/C++ Toolchain](https://github.com/ziglang/zig) >= 0.14.0
 
 BeatportDL uses [TagLib](https://taglib.org/) C bindings to handle audio metadata and therefore requires [CGO](https://go.dev/wiki/cgo)
 
@@ -176,13 +192,15 @@ Makefile is adapted for cross-compilation and uses [Zig toolchain](https://githu
 
 To compile BeatportDL with Zig using Makefile, you must specify the paths to the C/C++ libraries folder and headers folder for the desired OS and architecture with `-L` (for libraries) and `-I` (for headers) flags using environment variables: `MACOS_ARM64_LIB_PATH`, `MACOS_AMD64_LIB_PATH`, `LINUX_AMD64_LIB_PATH`, `LINUX_ARM64_LIB_PATH`, `WINDOWS_AMD64_LIB_PATH`
 
-One line example *(for unix and unix-like os)*
+One line example _(for unix and unix-like os)_
+
 ```shell
 MACOS_ARM64_LIB_PATH="-L/usr/local/lib -I/usr/local/include" \
 make darwin-arm64
 ```
 
 You can also create an `.env` file in the project folder and specify all environment variables in it:
+
 ```
 MACOS_ARM64_LIB_PATH=-L/libraries/for/macos-arm64 -I/headers/for/macos-arm64
 MACOS_AMD64_LIB_PATH=-L/libraries/for/macos-amd64 -I/headers/for/macos-amd64

--- a/internal/beatport/charts.go
+++ b/internal/beatport/charts.go
@@ -45,6 +45,23 @@ func (c *Chart) DirectoryName(n NamingPreferences) string {
 	return SanitizePath(directoryName, n.Whitespace)
 }
 
+// DirectoryNameWithFirstTrackGenre creates a directory name using the genre from the first track
+func (c *Chart) DirectoryNameWithFirstTrackGenre(n NamingPreferences, firstTrackGenre string) string {
+	templateValues := map[string]string{
+		"id":             strconv.Itoa(int(c.ID)),
+		"name":           SanitizeForPath(c.Name),
+		"slug":           c.Slug,
+		"first_genre":    SanitizeForPath(firstTrackGenre),
+		"track_count":    NumberWithPadding(c.TrackCount, c.TrackCount, n.TrackNumberPadding),
+		"creator":        SanitizeForPath(c.Person.OwnerName),
+		"created_date":   c.AddDate.Format("2006-01-02"),
+		"published_date": c.PublishDate.Format("2006-01-02"),
+		"updated_date":   c.ChangeDate.Format("2006-01-02"),
+	}
+	directoryName := ParseTemplate(n.Template, templateValues)
+	return SanitizePath(directoryName, n.Whitespace)
+}
+
 func (b *Beatport) GetChart(id int64) (*Chart, error) {
 	res, err := b.fetch(
 		"GET",

--- a/internal/beatport/playlists.go
+++ b/internal/beatport/playlists.go
@@ -50,6 +50,28 @@ func (p *Playlist) DirectoryName(n NamingPreferences) string {
 	return SanitizePath(directoryName, n.Whitespace)
 }
 
+// DirectoryNameWithFirstTrackGenre creates a directory name using the genre from the first track
+func (p *Playlist) DirectoryNameWithFirstTrackGenre(n NamingPreferences, firstTrackGenre string) string {
+	var bpmRange string
+
+	if len(p.BPMRange) > 0 && p.BPMRange[0] != nil && p.BPMRange[1] != nil {
+		bpmRange = fmt.Sprintf("%d-%d", *p.BPMRange[0], *p.BPMRange[1])
+	}
+
+	templateValues := map[string]string{
+		"id":           strconv.Itoa(int(p.ID)),
+		"name":         SanitizeForPath(p.Name),
+		"first_genre":  SanitizeForPath(firstTrackGenre),
+		"track_count":  NumberWithPadding(p.TrackCount, p.TrackCount, n.TrackNumberPadding),
+		"bpm_range":    bpmRange,
+		"length":       p.LengthMs.Display(),
+		"created_date": p.CreatedDate.Format("2006-01-02"),
+		"updated_date": p.UpdatedDate.Format("2006-01-02"),
+	}
+	directoryName := ParseTemplate(n.Template, templateValues)
+	return SanitizePath(directoryName, n.Whitespace)
+}
+
 func (b *Beatport) GetPlaylist(id int64) (*Playlist, error) {
 	res, err := b.fetch(
 		"GET",


### PR DESCRIPTION
…hart

Fix for https://github.com/unspok3n/beatportdl/issues/99

### Problem
The first_genre parameter was using metadata from the playlist/chart API response (playlist.Genres[0] or chart.Genres[0].Name) instead of the actual genre of the first track in the playlist/chart.

### Result
Before: A playlist with metadata genre "Electronic" but first track genre "Afro House" would create a folder with "Electronic"
After: The same playlist will create a folder with "Afro House" as the genre
