### PR TITLE
Fix BPM tag not persisting in M4A files

### DIFF
--- a/config/tag_mappings.go
+++ b/config/tag_mappings.go
@@ -85,7 +85,7 @@ var (
 			"track_number":  "TRACKNUMBER",
 			"track_genre":   "GENRE",
 			"track_key":     "KEY",
-			"track_bpm":     "BPM",
+			"track_bpm":     "BPM_raw",
 			"track_isrc":    "ISRC",
 
 			"release_name":           "ALBUM",


### PR DESCRIPTION
## Summary

- The default M4A tag mapping for `track_bpm` uses `"BPM"`, which is passed to taglib's `SetProperty`. However, `SetProperty` doesn't map `BPM` to a valid MP4 atom, so the value is silently discarded on save.
- Changing to `"BPM_raw"` routes it through `SetItemMp4` instead, which writes it as a freeform MP4 item (`----:com.apple.iTunes:BPM`) that persists correctly.
- FLAC is unaffected — Vorbis comments support arbitrary property names, so `SetProperty("BPM", ...)` works fine there.

## One-line fix

```diff
-			"track_bpm":     "BPM",
+			"track_bpm":     "BPM_raw",
```

## Test plan

- [x] Download M4A track from Beatport with `fix_tags: true`
- [x] Verify `TAG:BPM=<value>` appears in `ffprobe` output
- [x] Confirmed BPM was missing before fix, present after

🤖 Generated with [Claude Code](https://claude.com/claude-code)