### PR TITLE
perf: reuse compiled regexp/replacers on hot paths; fix HLS segment body leak

### DIFF
--- a/cmd/beatportdl/needledrop.go
+++ b/cmd/beatportdl/needledrop.go
@@ -6,9 +6,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/grafov/m3u8"
-	"github.com/vbauerster/mpb/v8"
 	"io"
 	"net/http"
 	"net/url"
@@ -18,6 +15,10 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/grafov/m3u8"
+	"github.com/vbauerster/mpb/v8"
 )
 
 type StreamKey struct {
@@ -105,24 +106,28 @@ func (app *application) downloadSegments(path string, segmentUrls []string, key 
 	}
 
 	for _, segmentUrl := range segmentUrls {
-		req, err := http.Get(segmentUrl)
-		if err != nil {
-			return "", err
-		}
-		defer req.Body.Close()
-		if req.StatusCode != http.StatusOK {
-			return "", errors.New(req.Status)
-		}
-		segBytes, err := io.ReadAll(req.Body)
-		if err != nil {
-			return "", err
-		}
-		decSegBytes, err := decryptSegment(segBytes, key)
-		if err != nil {
-			return "", err
-		}
-		_, err = file.Write(decSegBytes)
-		if err != nil {
+		if err := func() error {
+			resp, err := http.Get(segmentUrl)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				return errors.New(resp.Status)
+			}
+			segBytes, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
+			decSegBytes, err := decryptSegment(segBytes, key)
+			if err != nil {
+				return err
+			}
+			if _, err := file.Write(decSegBytes); err != nil {
+				return err
+			}
+			return nil
+		}(); err != nil {
 			return "", err
 		}
 		if bar != nil {

--- a/internal/beatport/utils.go
+++ b/internal/beatport/utils.go
@@ -19,6 +19,34 @@ type NamingPreferences struct {
 	KeySystem          string
 }
 
+// These regexps and replacers are immutable and reused on hot paths
+// (filename and directory templating, JSON unmarshalling), so they are
+// compiled once at package initialization instead of on every call.
+var (
+	templatePlaceholderRegexp = regexp.MustCompile(`\{(\w+)}`)
+
+	sanitizedStringReplacer = strings.NewReplacer(
+		"\\n", "",
+		"\\r", "",
+		"\\t", "",
+	)
+
+	sanitizeForPathReplacer = strings.NewReplacer(
+		"\\", "",
+		"/", "",
+	)
+
+	sanitizePathReplacer = strings.NewReplacer(
+		"<", "",
+		">", "",
+		":", "",
+		"\"", "",
+		"|", "",
+		"?", "",
+		"*", "",
+	)
+)
+
 func (d *Duration) Display() string {
 	seconds := *d / 1000
 	hours := seconds / 3600
@@ -32,12 +60,7 @@ func (d *Duration) Display() string {
 
 func (s *SanitizedString) UnmarshalJSON(data []byte) error {
 	rawValue := string(bytes.Trim(data, `"`))
-	r := strings.NewReplacer(
-		"\\n", "",
-		"\\r", "",
-		"\\t", "",
-	)
-	sanitized := r.Replace(rawValue)
+	sanitized := sanitizedStringReplacer.Replace(rawValue)
 	*s = SanitizedString(strings.Join(strings.Fields(sanitized), " "))
 	return nil
 }
@@ -47,11 +70,7 @@ func (s *SanitizedString) String() string {
 }
 
 func SanitizeForPath(s string) string {
-	r := strings.NewReplacer(
-		"\\", "",
-		"/", "",
-	)
-	return strings.Join(strings.Fields(r.Replace(s)), " ")
+	return strings.Join(strings.Fields(sanitizeForPathReplacer.Replace(s)), " ")
 }
 
 func SanitizePath(name string, whitespace string) string {
@@ -59,22 +78,10 @@ func SanitizePath(name string, whitespace string) string {
 		name = name[:250]
 	}
 
-	oldnew := []string{
-		"<", "",
-		">", "",
-		":", "",
-		"\"", "",
-		"|", "",
-		"?", "",
-		"*", "",
-	}
-
+	name = sanitizePathReplacer.Replace(name)
 	if whitespace != "" {
-		oldnew = append(oldnew, " ", whitespace)
+		name = strings.ReplaceAll(name, " ", whitespace)
 	}
-
-	r := strings.NewReplacer(oldnew...)
-	name = r.Replace(name)
 
 	return strings.Join(strings.Fields(name), " ")
 }
@@ -87,8 +94,7 @@ func NumberWithPadding(value, total, padding int) string {
 }
 
 func ParseTemplate(template string, values map[string]string) string {
-	re := regexp.MustCompile(`\{(\w+)}`)
-	result := re.ReplaceAllStringFunc(template, func(placeholder string) string {
+	result := templatePlaceholderRegexp.ReplaceAllStringFunc(template, func(placeholder string) string {
 		key := strings.Trim(placeholder, "{}")
 		if value, found := values[key]; found {
 			return value

--- a/internal/beatport/utils_test.go
+++ b/internal/beatport/utils_test.go
@@ -1,0 +1,99 @@
+package beatport
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+var benchTemplate = "{number}. {artists} - {name} ({mix_name}) [{catalog_number}] {bpm} {key}"
+
+var benchTemplateValues = map[string]string{
+	"number":         "03",
+	"artists":        "Deadmau5, Kaskade",
+	"name":           "I Remember",
+	"mix_name":       "Original Mix",
+	"catalog_number": "MAU5001",
+	"bpm":            "128",
+	"key":            "Bbm",
+}
+
+func TestParseTemplate(t *testing.T) {
+	got := ParseTemplate("{artists} - {name}", map[string]string{
+		"artists": "Deadmau5",
+		"name":    "Strobe",
+	})
+	want := "Deadmau5 - Strobe"
+	if got != want {
+		t.Fatalf("ParseTemplate() = %q, want %q", got, want)
+	}
+
+	// Unknown placeholders must be left intact.
+	got = ParseTemplate("{name} {unknown}", map[string]string{"name": "Strobe"})
+	want = "Strobe {unknown}"
+	if got != want {
+		t.Fatalf("ParseTemplate() = %q, want %q", got, want)
+	}
+}
+
+func TestSanitizeForPath(t *testing.T) {
+	got := SanitizeForPath("AC/DC \\ Back\tIn  Black")
+	want := "ACDC Back In Black"
+	if got != want {
+		t.Fatalf("SanitizeForPath() = %q, want %q", got, want)
+	}
+}
+
+func TestSanitizePath(t *testing.T) {
+	got := SanitizePath(`a<b>c:d"e|f?g*h`, "")
+	want := "abcdefgh"
+	if got != want {
+		t.Fatalf("SanitizePath() = %q, want %q", got, want)
+	}
+
+	got = SanitizePath("hello world", "_")
+	want = "hello_world"
+	if got != want {
+		t.Fatalf("SanitizePath(whitespace) = %q, want %q", got, want)
+	}
+}
+
+func TestSanitizedStringUnmarshal(t *testing.T) {
+	var s SanitizedString
+	if err := json.Unmarshal([]byte(`"  Strobe\n\t (Original  Mix) "`), &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	want := "Strobe (Original Mix)"
+	if s.String() != want {
+		t.Fatalf("SanitizedString = %q, want %q", s.String(), want)
+	}
+}
+
+func BenchmarkParseTemplate(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = ParseTemplate(benchTemplate, benchTemplateValues)
+	}
+}
+
+func BenchmarkSanitizePath(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = SanitizePath(`Deadmau5 - I Remember (Original Mix) <feat. Kaskade>`, "")
+	}
+}
+
+func BenchmarkSanitizeForPath(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = SanitizeForPath(`Deadmau5 / Kaskade \ I Remember`)
+	}
+}
+
+func BenchmarkSanitizedStringUnmarshal(b *testing.B) {
+	data := []byte(`"  Deadmau5 - I Remember\n\t (Original  Mix) "`)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var s SanitizedString
+		_ = json.Unmarshal(data, &s)
+	}
+}


### PR DESCRIPTION
## Summary

Two small, self-contained improvements I found while reading through the code:

1. **perf** — avoid recompiling a regexp and rebuilding constant `strings.Replacer`s on hot paths
2. **fix** — close each HLS segment's HTTP response body promptly instead of holding them all open until the download finishes

Each change is in its own commit so they're easy to review (or drop) independently.

---

### 1. Hot-path allocations — `internal/beatport/utils.go`

`ParseTemplate` called `regexp.MustCompile` on **every** call, and `SanitizePath`, `SanitizeForPath` and `SanitizedString.UnmarshalJSON` rebuilt constant `strings.Replacer` values on every call. These run once per track filename, once per directory name and once per unmarshalled JSON field, so on a large chart/label download (hundreds of tracks) the repeated compilation/allocation adds up to noticeable CPU and GC pressure.

They're now compiled once as package-level vars. Behaviour is unchanged — I added characterization tests first (the package had no tests) and confirmed they pass identically before and after the change.

Benchmarks (Apple M4 Pro, go1.25, `-benchmem -benchtime=2s`):

| Function | Before | After | Speedup |
|---|---|---|---|
| `ParseTemplate` | 1617 ns, 2112 B, 29 allocs | 876 ns, 273 B, 6 allocs | ~1.85× |
| `SanitizePath` | 893 ns, 7248 B, 8 allocs | 189 ns, 320 B, 4 allocs | ~4.7× |
| `SanitizeForPath` | 756 ns, 6816 B, 7 allocs | 114 ns, 128 B, 3 allocs | ~6.6× |
| `SanitizedString.UnmarshalJSON` | 870 ns, 1368 B, 17 allocs | 373 ns, 472 B, 8 allocs | ~2.3× |

### 2. HLS segment response-body leak — `cmd/beatportdl/needledrop.go`

`downloadSegments` used `defer resp.Body.Close()` **inside** the segment loop, so every segment's response body stayed open until the whole track finished downloading. For `medium-hls` tracks (which can have many segments) that keeps connections and file descriptors open for the entire download. Each request is now scoped in a closure so its body is closed at the end of each iteration.

---

### Testing

- `go build ./...` and `go vet ./...` clean (built with TagLib 2.3)
- New tests + benchmarks pass; existing behaviour preserved (gofmt clean)

Happy to split this into two PRs or adjust anything if you'd prefer. Thanks for the project!
